### PR TITLE
Finishes functionality for user story 32

### DIFF
--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,3 +1,4 @@
 <h1>Viewing <%= @user.username %>'s profile </h1>
 <%= render './show' %>
 <%= link_to "Edit This Profile", edit_admin_user_path(@user) %>
+<%= link_to "#{@user.username}'s Orders", admin_user_orders_path %>

--- a/app/views/merchant/users/show.html.erb
+++ b/app/views/merchant/users/show.html.erb
@@ -1,7 +1,7 @@
 <%= flash.each do |type, message|  %>
 <%= content_tag :div, message, class: type %>
 <% end %>
-<%= link_to "My Items", merchant_items_path %>
+<%= link_to "My Items", merchant_dashboard_items_path %>
 
 <%= "Username: #{@merchant.username}" %>
 <%= "Email: #{@merchant.email}" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,9 +38,11 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :users, only: [:index, :show, :edit]
+    get '/user/orders', to: 'orders#show'
     get 'admin/user/enable', to: 'users#enable', as: :user_enable
     get 'admin/user/disable', to: 'users#disable', as: :user_disable
     get 'admin/merchants/dashboard', to: 'merchants#show', as: :merchant_dashboard
     get 'admin/merchant/downgrade', to: 'merchants#downgrade', as: :merchant_downgrade
+
   end
 end

--- a/spec/features/admin/user_show_spec.rb
+++ b/spec/features/admin/user_show_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'As and admin' do
       expect(page).to have_content("#{user_1.city}")
       expect(page).to have_content("#{user_1.state}")
       expect(page).to have_content("#{user_1.zip_code}")
+      expect(page).to have_content("#{user_1.username}'s Orders")
 
       expect(page).to_not have_content("#{user_1.password}")
       expect(page).to_not have_content("#{user_1.password_digest}")

--- a/spec/features/nav_bar_spec.rb
+++ b/spec/features/nav_bar_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'User sees nav bar' do
       expect(page).to have_link("Log Out")
       expect(page).to_not have_link("Log In")
       expect(page).to_not have_link("Orders")
-      # expect(page).to_not have_link("Cart")
+      expect(page).to_not have_link("Cart")
+      expect(page).to_not have_link("My Orders")
     end
   end
 
@@ -73,6 +74,7 @@ RSpec.describe 'User sees nav bar' do
       expect(page).to have_link("My Profile")
       expect(page).to have_link("My Orders")
       expect(page).to have_link("Log Out")
+      expect(page).to have_link("My Orders")
       expect(page).to have_content("Logged in as #{user.username}")
 
       expect(page).to_not have_link("Log In")


### PR DESCRIPTION
Adds functionality as per Ian's instruction for seeing orders link in nave bar as a user but not an admin
closes #40 